### PR TITLE
Check different behaviour based on command line switches.

### DIFF
--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+from optparse import OptionParser
+
+import timedRun
+import filecmp
+
+
+def parseOptions(arguments):
+    parser = OptionParser()
+    parser.disable_interspersed_args()
+    parser.add_option('-t', '--timeout', type='int', action='store', dest='condTimeout',
+                      default=120,
+                      help='Optionally set the timeout. Defaults to "%default" seconds.')
+    parser.add_option('-a', '--a-arg', type='string', action='append', dest='aArgs',
+                      default=[],
+                      help='Set of extra arguments given to first run.')
+    parser.add_option('-b', '--b-arg', type='string', action='append', dest='bArgs',
+                      default=[],
+                      help='Set of extra arguments given to second run.')
+
+    options, args = parser.parse_args(arguments)
+
+    return options.condTimeout, options.aArgs, options.bArgs, args
+
+def interesting(cliArgs, tempPrefix):
+    (timeout, aArgs, bArgs, args) = parseOptions(cliArgs)
+
+    aRuninfo = timedRun.timed_run(args[:1] + aArgs + args[1:], timeout, tempPrefix + "-a")
+    bRuninfo = timedRun.timed_run(args[:1] + bArgs + args[1:], timeout, tempPrefix + "-b")
+    timeString = " (1st Run: %.3f seconds) (2nd Run: %.3f seconds)" % (aRuninfo.elapsedtime, bRuninfo.elapsedtime)
+
+    if aRuninfo.sta != timedRun.TIMED_OUT and bRuninfo.sta != timedRun.TIMED_OUT:
+        if aRuninfo.rc != bRuninfo.rc:
+            print ("[Interesting] Different return code. (%d, %d) " % (aRuninfo.rc, bRuninfo.rc)) + timeString
+            return True
+        if not filecmp.cmp(aRuninfo.out, bRuninfo.out):
+            print "[Interesting] Different output. " + timeString
+            return True
+        if not filecmp.cmp(aRuninfo.err, bRuninfo.err):
+            print "[Interesting] Different error output. " + timeString
+            return True
+    else:
+        print "[Uninteresting] At least one test timed out." + timeString
+        return False
+
+    print "[Uninteresting] Identical behaviour." + timeString
+    return False


### PR DESCRIPTION
This modification add a `diffTest` test which run the program twice and check differences in terms of exit code, output, and error output.  This command accept the usual `-t` argument to define a time out, and a `-a`, `-b` arguments.  These arguments are used to append extra arguments in the A/B testing which is made.

Thus running lithium as such:

```
  $ lihtium.py diffTest -t 1 -a --no-baseline -b --no-ion ./js foo.js
```

will run the following commands on the different versions of `foo.js` generated by the strategies of lithium:

```
  $ ./js --no-baseline foo.js
  $ ./js --no-ion foo.js
```

This is useful for reducing test cases which have different behaviour, as well as for testing new features.
